### PR TITLE
Add option to select only specific fields

### DIFF
--- a/lib/mongoose-api-query.js
+++ b/lib/mongoose-api-query.js
@@ -11,6 +11,9 @@ module.exports = exports = function apiQueryPlugin(schema) {
         if (params.sort) {
             query = query.sort(params.sort);
         }
+        if (params.select) {
+            query = query.select(params.select)
+        }
         return cb ? query.exec(cb) : query;
     };
 
@@ -25,6 +28,9 @@ module.exports = exports = function apiQueryPlugin(schema) {
         }
         if (params.sort) {
             query = query.sort(params.sort);
+        }
+        if (params.select) {
+            query = query.select(params.select)
         }
 
         return cb ? query.exec(cb) : query;
@@ -41,7 +47,8 @@ module.exports = exports = function apiQueryPlugin(schema) {
         var searchParams = {}
             , page = 1
             , per_page = 10
-            , sort = false;
+            , sort = false
+            , select = undefined;
 
         var parseSchemaForKey = function (schema, keyPrefix, lcKey, val, operator) {
 
@@ -201,6 +208,12 @@ module.exports = exports = function apiQueryPlugin(schema) {
                 var parts = val.split(',');
                 sort = {};
                 sort[parts[0]] = parts.length > 1 ? parts[1] : 1;
+            } else if (lcKey === "selected_fields") {
+                var parts = val.split(',');
+                select = parts.reduce(function(subSelect, part) {
+                    subSelect[part] = 1;
+                    return subSelect;
+                }, {});
             } else {
                 parseSchemaForKey(model.schema, "", lcKey, val, operator);
             }
@@ -232,7 +245,8 @@ module.exports = exports = function apiQueryPlugin(schema) {
             searchParams: searchParams,
             page:         page,
             per_page:     per_page,
-            sort:         sort
+            sort:         sort,
+            select:       select
         };
 
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mongoose-api-query",
-  "version": "0.2.0",
+  "name": "@valiton/mongoose-api-query",
+  "version": "0.3.0",
   "author": "Adam Jacob Becker <ad@mbecker.cc>",
   "description": "Given a Mongoose model and an array of URI params, construct a query for use in a search API.",
   "keywords": [
@@ -22,5 +22,5 @@
   "dependencies": {
     "mongoose": "5.4.19"
   },
-  "homepage": "http://github.com/adamjacobbecker/mongoose-api-query"
+  "homepage": "http://github.com/valiton/mongoose-api-query"
 }

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,13 @@ geo near, with (optional) radius in miles:
 /monsters?sort_by=name,desc
 ```
 
+##### Selecting only specific fields
+
+```
+/monsters?selected_fields=name          // select only _id and name field
+/monsters?selected_fields=name,title    // select only _id, name and title field
+```
+
 ##### Schemaless search
 
 Do you have a property defined in your schema like `data: {}`, that can have anything inside it? You can search that, too, and it will be treated as a string.

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,21 @@ var hasMonstersInOrder = function (monster1, monster2) {
   expect(index1).to.be.lessThan(index2);
 };
 
+var hasMonstersProperties = function(properties) {
+  var json = JSON.parse(browser.text());
+
+  var jsonProperties = json.reduce(function createDistinctPropertyMap(propMap, monster) {
+    for (var prop in monster) {
+      if (prop == '__v') continue;
+
+      propMap[prop] = 1;
+    }
+    return propMap;
+  }, {})
+
+  expect(Object.keys(jsonProperties).sort().join(',')).to.be.equal(properties.sort().join(','));
+};
+
 describe('mongoose-api-query', function(){
 
   it('without any query params, loads all monsters', function(done){
@@ -67,6 +82,33 @@ describe('mongoose-api-query', function(){
   it('"desc" is valid sort order', function(done){
     browser.visit("http://localhost:3000/test1?sort_by=monster_identification_no,desc", function () {
       hasMonstersInOrder("Bessie the Lochness Monster", "Big Purple People Eater");
+      done();
+    });
+  });
+
+  it('select all attributes if select field is not set', function(done) {
+    browser.visit("http://localhost:3000/test1", function () {
+      hasMonstersProperties([
+        '_id',
+        'name',
+        'title',
+        'tax_identification_no',
+        'monster_identification_no',
+        'monster_object_id',
+        'eats_humans',
+        'foods',
+        'vegetarian',
+        'vegan_since',
+        'loc',
+        'data'
+      ]);
+      done();
+    });
+  });
+
+  it('can select for only specific attributes', function(done) {
+    browser.visit("http://localhost:3000/test1?selected_fields=monster_identification_no,name", function () {
+      hasMonstersProperties(["_id", "monster_identification_no", "name"]);
       done();
     });
   });


### PR DESCRIPTION
The request allows over the "select_fields" argument to select only specific fields from the model. Multiple fields can be separated with a comma. 